### PR TITLE
add AWSCodeCommitFullAccess role to our instance

### DIFF
--- a/static/assets/cloudformation/infra-lab1.yml
+++ b/static/assets/cloudformation/infra-lab1.yml
@@ -150,6 +150,8 @@ Resources:
             Action: 
               - "sts:AssumeRole"
       Path: "/"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/AWSCodeCommitFullAccess"
       Policies:
         - 
           PolicyName: "ReadAndWriteS3"

--- a/static/assets/cloudformation/infra-lab2.yml
+++ b/static/assets/cloudformation/infra-lab2.yml
@@ -230,6 +230,8 @@ Resources:
             Action: 
               - "sts:AssumeRole"
       Path: "/"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/AWSCodeCommitFullAccess"
       Policies:
         - 
           PolicyName: "ReadAndWriteS3"

--- a/static/assets/cloudformation/infra-lab3.yml
+++ b/static/assets/cloudformation/infra-lab3.yml
@@ -230,6 +230,8 @@ Resources:
             Action: 
               - "sts:AssumeRole"
       Path: "/"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/AWSCodeCommitFullAccess"
       Policies:
         - 
           PolicyName: "ReadAndWriteS3"

--- a/static/assets/cloudformation/infra-lab4.yml
+++ b/static/assets/cloudformation/infra-lab4.yml
@@ -230,6 +230,8 @@ Resources:
             Action: 
               - "sts:AssumeRole"
       Path: "/"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/AWSCodeCommitFullAccess"
       Policies:
         - 
           PolicyName: "ReadAndWriteS3"

--- a/static/assets/cloudformation/infra-lab5.yml
+++ b/static/assets/cloudformation/infra-lab5.yml
@@ -230,6 +230,8 @@ Resources:
             Action: 
               - "sts:AssumeRole"
       Path: "/"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/AWSCodeCommitFullAccess"
       Policies:
         - 
           PolicyName: "ReadAndWriteS3"

--- a/static/assets/cloudformation/infra-lab6.yml
+++ b/static/assets/cloudformation/infra-lab6.yml
@@ -230,6 +230,8 @@ Resources:
             Action: 
               - "sts:AssumeRole"
       Path: "/"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/AWSCodeCommitFullAccess"
       Policies:
         - 
           PolicyName: "ReadAndWriteS3"

--- a/static/assets/cloudformation/infra-lab7.yml
+++ b/static/assets/cloudformation/infra-lab7.yml
@@ -234,6 +234,8 @@ Resources:
             Action:
               - "sts:AssumeRole"
       Path: "/"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/AWSCodeCommitFullAccess"
       Policies:
         -
           PolicyName: "ReadAndWriteS3"

--- a/static/assets/cloudformation/infra-lab8.yml
+++ b/static/assets/cloudformation/infra-lab8.yml
@@ -234,6 +234,8 @@ Resources:
             Action: 
               - "sts:AssumeRole"
       Path: "/"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/AWSCodeCommitFullAccess"
       Policies:
         - 
           PolicyName: "ReadAndWriteS3"


### PR DESCRIPTION
… so federated users we can use the AWS CLI git helper rather than creating an IAM user.

Any user using a corp account is likely to be using Federated access.